### PR TITLE
support for intermediate filters in ltn12.pump.all

### DIFF
--- a/doc/ltn12.html
+++ b/doc/ltn12.html
@@ -138,11 +138,16 @@ end
 <!-- all ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 
 <p class=name id="pump.all">
-ltn12.pump.<b>all(</b>source, sink<b>)</b>
+  ltn12.pump.<b>all(</b>source, 
+  [filter<sub>1</sub>, filter<sub>2</sub>, ... filter<sub>N</sub>,]
+  sink<b>)</b>
 </p>
 
 <p class=description>
-Pumps <em>all</em> data from a <tt>source</tt> to a <tt>sink</tt>. 
+Pumps <em>all</em> data from a <tt>source</tt> to a <tt>sink</tt>. If
+additional filter
+parameter <tt>filter<sub>1</sub> ... filter<sub>N</sub></tt> are
+provided, they are inserted between the source and the sink.
 </p>
 
 <p class=return>
@@ -174,11 +179,16 @@ of error, the function returns a <b><tt>false</tt></b> value, followed by an err
 <!-- chain ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 
 <p class=name id="sink.chain">
-ltn12.sink.<b>chain(</b>filter, sink<b>)</b>
+  ltn12.sink.<b>chain(</b>filter<sub>1</sub>[,
+    filter<sub>2</sub> , ... filter<sub>N</sub>],
+    sink
+    <b>)</b>
 </p>
 
 <p class=description>
-Creates and returns a new sink that passes data through a <tt>filter</tt> before sending it to a given <tt>sink</tt>. 
+Creates and returns a new sink that passes data through
+<tt>filter<sub>1</sub> ... filter<sub>N</sub></tt> before sending it to
+a given <tt>sink</tt>.
 </p>
 
 <!-- error ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
@@ -313,12 +323,14 @@ The function returns the new source.
 <!-- chain ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 
 <p class=name id="source.chain">
-ltn12.source.<b>chain(</b>source, filter<b>)</b>
+  ltn12.source.<b>chain(</b>source, filter<sub>1</sub>[,
+  filter<sub>2</sub> , ... filter<sub>N</sub>]<b>)</b>
 </p>
 
 <p class=description>
-Creates a new <tt>source</tt> that passes data through a <tt>filter</tt> 
-before returning it. 
+  Creates a new <tt>source</tt> that passes data through
+  <tt>filter<sub>1</sub> ... filter<sub>N</sub></tt>
+  before returning it.
 </p>
 
 <p class=return>

--- a/src/ltn12.lua
+++ b/src/ltn12.lua
@@ -283,14 +283,17 @@ end
 -----------------------------------------------------------------------------
 -- pumps one chunk from the source to the sink
 function pump.step(src, snk)
+    if ... then snk = ltn12.sink.chain(snk, ...) end
     local chunk, src_err = src()
     local ret, snk_err = snk(chunk, src_err)
     if chunk and ret then return 1
     else return nil, src_err or snk_err end
 end
 
--- pumps all data from a source to a sink, using a step function
-function pump.all(src, snk, step)
+-- pumps all data from a source to a sink, optionally going through
+-- intermediate filters
+function pump.all(src, snk, ...)
+    if ... then snk = ltn12.sink.chain(snk, ...) end
     base.assert(src and snk)
     step = step or pump.step
     while true do

--- a/test/ltn12test.lua
+++ b/test/ltn12test.lua
@@ -230,6 +230,14 @@ assert(table.concat(t) == double(double(double(s))), "mismatch")
 print("ok")
 
 --------------------------------
+io.write("testing pump.all (with intermediate filters): ")
+local source = ltn12.source.string(s)
+sink, t = ltn12.sink.table()
+assert(ltn12.pump.all(source, double, double, sink), "returned error")
+assert(table.concat(t) == double(double(s)), "mismatch")
+print("ok")
+
+--------------------------------
 io.write("testing filter.chain (and sink.chain, with split, merge): ")
 source = ltn12.source.string(s)
 filter = split(5)


### PR DESCRIPTION
It removes the optional step argument in ltn12.pump.all, but I've never seen it used and I can't think of a realistic use case for it.

It depends on the version of ltn12.sink.chain() which accepts multiple filter parameters.
