### PR TITLE
Publish API used by luasec

### DIFF
--- a/src/buffer.h
+++ b/src/buffer.h
@@ -20,6 +20,8 @@
 #include "io.h"
 #include "timeout.h"
 
+#include "common.h"
+
 /* buffer size in bytes */
 #define BUF_SIZE 8192
 
@@ -34,12 +36,12 @@ typedef struct t_buffer_ {
 } t_buffer;
 typedef t_buffer *p_buffer;
 
-int buffer_open(lua_State *L);
-void buffer_init(p_buffer buf, p_io io, p_timeout tm);
-int buffer_meth_send(lua_State *L, p_buffer buf);
-int buffer_meth_receive(lua_State *L, p_buffer buf);
-int buffer_meth_getstats(lua_State *L, p_buffer buf);
-int buffer_meth_setstats(lua_State *L, p_buffer buf);
-int buffer_isempty(p_buffer buf);
+LUASOCKET_API int buffer_open(lua_State *L);
+LUASOCKET_API void buffer_init(p_buffer buf, p_io io, p_timeout tm);
+LUASOCKET_API int buffer_meth_send(lua_State *L, p_buffer buf);
+LUASOCKET_API int buffer_meth_receive(lua_State *L, p_buffer buf);
+LUASOCKET_API int buffer_meth_getstats(lua_State *L, p_buffer buf);
+LUASOCKET_API int buffer_meth_setstats(lua_State *L, p_buffer buf);
+LUASOCKET_API int buffer_isempty(p_buffer buf);
 
 #endif /* BUF_H */

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,16 @@
+#ifndef LUASOCKET_COMMON_H
+#define LUASOCKET_COMMON_H
+
+#ifndef LUASOCKET_API
+#define LUASOCKET_API extern
+#endif
+
+#ifndef UNIX_API
+#define UNIX_API extern
+#endif
+
+#ifndef MIME_API
+#define MIME_API extern
+#endif
+
+#endif

--- a/src/io.h
+++ b/src/io.h
@@ -15,6 +15,8 @@
 #include <stdio.h>
 #include "lua.h"
 
+#include "common.h"
+
 #include "timeout.h"
 
 /* IO error codes */
@@ -58,8 +60,9 @@ typedef struct t_io_ {
 } t_io;
 typedef t_io *p_io;
 
-void io_init(p_io io, p_send send, p_recv recv, p_error error, void *ctx);
-const char *io_strerror(int err);
+LUASOCKET_API void io_init(p_io io, p_send send, p_recv recv,
+        p_error error, void *ctx);
+LUASOCKET_API const char *io_strerror(int err);
 
 #endif /* IO_H */
 

--- a/src/socket.h
+++ b/src/socket.h
@@ -11,6 +11,8 @@
 \*=========================================================================*/
 #include "io.h"
 
+#include "common.h"
+
 /*=========================================================================*\
 * Platform specific compatibilization
 \*=========================================================================*/
@@ -35,44 +37,53 @@ typedef struct sockaddr SA;
 * Functions bellow implement a comfortable platform independent 
 * interface to sockets
 \*=========================================================================*/
-int socket_open(void);
-int socket_close(void);
-void socket_destroy(p_socket ps);
-void socket_shutdown(p_socket ps, int how); 
-int socket_sendto(p_socket ps, const char *data, size_t count, 
-        size_t *sent, SA *addr, socklen_t addr_len, p_timeout tm);
-int socket_recvfrom(p_socket ps, char *data, size_t count, 
-        size_t *got, SA *addr, socklen_t *addr_len, p_timeout tm);
-
-void socket_setnonblocking(p_socket ps);
-void socket_setblocking(p_socket ps);
-
-int socket_waitfd(p_socket ps, int sw, p_timeout tm);
-int socket_select(t_socket n, fd_set *rfds, fd_set *wfds, fd_set *efds, 
+LUASOCKET_API int socket_open(void);
+LUASOCKET_API int socket_close(void);
+LUASOCKET_API void socket_destroy(p_socket ps);
+LUASOCKET_API void socket_shutdown(p_socket ps, int how);
+LUASOCKET_API int socket_sendto(p_socket ps, const char *data,
+        size_t count, size_t *sent, SA *addr, socklen_t addr_len,
+        p_timeout tm);
+LUASOCKET_API int socket_recvfrom(p_socket ps, char *data,
+        size_t count, size_t *got, SA *addr, socklen_t *addr_len,
         p_timeout tm);
 
-int socket_connect(p_socket ps, SA *addr, socklen_t addr_len, p_timeout tm); 
-int socket_create(p_socket ps, int domain, int type, int protocol);
-int socket_bind(p_socket ps, SA *addr, socklen_t addr_len); 
-int socket_listen(p_socket ps, int backlog);
-int socket_accept(p_socket ps, p_socket pa, SA *addr, 
+LUASOCKET_API void socket_setnonblocking(p_socket ps);
+LUASOCKET_API void socket_setblocking(p_socket ps);
+
+LUASOCKET_API int socket_waitfd(p_socket ps, int sw, p_timeout tm);
+LUASOCKET_API int socket_select(t_socket n, fd_set *rfds, fd_set *wfds,
+        fd_set *efds, p_timeout tm);
+
+LUASOCKET_API int socket_connect(p_socket ps, SA *addr,
+        socklen_t addr_len, p_timeout tm);
+LUASOCKET_API int socket_create(p_socket ps, int domain, int type,
+        int protocol);
+LUASOCKET_API int socket_bind(p_socket ps, SA *addr,
+        socklen_t addr_len);
+LUASOCKET_API int socket_listen(p_socket ps, int backlog);
+LUASOCKET_API int socket_accept(p_socket ps, p_socket pa, SA *addr,
         socklen_t *addr_len, p_timeout tm);
 
-const char *socket_hoststrerror(int err);
-const char *socket_gaistrerror(int err);
-const char *socket_strerror(int err);
+LUASOCKET_API const char *socket_hoststrerror(int err);
+LUASOCKET_API const char *socket_gaistrerror(int err);
+LUASOCKET_API const char *socket_strerror(int err);
 
 /* these are perfect to use with the io abstraction module 
    and the buffered input module */
-int socket_send(p_socket ps, const char *data, size_t count, 
-        size_t *sent, p_timeout tm);
-int socket_recv(p_socket ps, char *data, size_t count, size_t *got, p_timeout tm);
-int socket_write(p_socket ps, const char *data, size_t count, 
-        size_t *sent, p_timeout tm);
-int socket_read(p_socket ps, char *data, size_t count, size_t *got, p_timeout tm);
-const char *socket_ioerror(p_socket ps, int err);
+LUASOCKET_API int socket_send(p_socket ps, const char *data,
+        size_t count, size_t *sent, p_timeout tm);
+LUASOCKET_API int socket_recv(p_socket ps, char *data, size_t count,
+        size_t *got, p_timeout tm);
+LUASOCKET_API int socket_write(p_socket ps, const char *data,
+        size_t count, size_t *sent, p_timeout tm);
+LUASOCKET_API int socket_read(p_socket ps, char *data, size_t count,
+        size_t *got, p_timeout tm);
+LUASOCKET_API const char *socket_ioerror(p_socket ps, int err);
 
-int socket_gethostbyaddr(const char *addr, socklen_t len, struct hostent **hp);
-int socket_gethostbyname(const char *addr, struct hostent **hp);
+LUASOCKET_API int socket_gethostbyaddr(const char *addr, socklen_t len,
+        struct hostent **hp);
+LUASOCKET_API int socket_gethostbyname(const char *addr,
+        struct hostent **hp);
 
 #endif /* SOCKET_H */

--- a/src/timeout.h
+++ b/src/timeout.h
@@ -6,6 +6,8 @@
 \*=========================================================================*/
 #include "lua.h"
 
+#include "common.h"
+
 /* timeout control structure */
 typedef struct t_timeout_ {
     double block;          /* maximum time for blocking calls */
@@ -14,14 +16,15 @@ typedef struct t_timeout_ {
 } t_timeout;
 typedef t_timeout *p_timeout;
 
-int timeout_open(lua_State *L);
-void timeout_init(p_timeout tm, double block, double total);
-double timeout_get(p_timeout tm);
-double timeout_getretry(p_timeout tm);
-p_timeout timeout_markstart(p_timeout tm);
-double timeout_getstart(p_timeout tm);
-double timeout_gettime(void);
-int timeout_meth_settimeout(lua_State *L, p_timeout tm);
+LUASOCKET_API int timeout_open(lua_State *L);
+LUASOCKET_API void timeout_init(p_timeout tm, double block,
+        double total);
+LUASOCKET_API double timeout_get(p_timeout tm);
+LUASOCKET_API double timeout_getretry(p_timeout tm);
+LUASOCKET_API p_timeout timeout_markstart(p_timeout tm);
+LUASOCKET_API double timeout_getstart(p_timeout tm);
+LUASOCKET_API double timeout_gettime(void);
+LUASOCKET_API int timeout_meth_settimeout(lua_State *L, p_timeout tm);
 
 #define timeout_iszero(tm)   ((tm)->block == 0.0)
 

--- a/src/usocket.c
+++ b/src/usocket.c
@@ -17,9 +17,6 @@
 #ifndef SOCKET_SELECT
 #include <sys/poll.h>
 
-#define WAITFD_R        POLLIN
-#define WAITFD_W        POLLOUT
-#define WAITFD_C        (POLLIN|POLLOUT)
 int socket_waitfd(p_socket ps, int sw, p_timeout tm) {
     int ret;
     struct pollfd pfd;
@@ -38,9 +35,6 @@ int socket_waitfd(p_socket ps, int sw, p_timeout tm) {
 }
 #else
 
-#define WAITFD_R        1
-#define WAITFD_W        2
-#define WAITFD_C        (WAITFD_R|WAITFD_W)
 
 int socket_waitfd(p_socket ps, int sw, p_timeout tm) {
     int ret;

--- a/src/usocket.h
+++ b/src/usocket.h
@@ -56,4 +56,20 @@ typedef struct sockaddr_storage t_sockaddr_storage;
 
 #define SOCKET_INVALID (-1)
 
+#ifndef SOCKET_SELECT
+#include <sys/poll.h>
+
+#define WAITFD_R        POLLIN
+#define WAITFD_W        POLLOUT
+#define WAITFD_C        (POLLIN|POLLOUT)
+
+#else
+
+#define WAITFD_R        1
+#define WAITFD_W        2
+#define WAITFD_C        (WAITFD_R|WAITFD_W)
+
+#endif
+
+
 #endif /* USOCKET_H */

--- a/src/wsocket.c
+++ b/src/wsocket.c
@@ -39,10 +39,6 @@ int socket_close(void) {
 /*-------------------------------------------------------------------------*\
 * Wait for readable/writable/connected socket with timeout
 \*-------------------------------------------------------------------------*/
-#define WAITFD_R        1
-#define WAITFD_W        2
-#define WAITFD_E        4
-#define WAITFD_C        (WAITFD_E|WAITFD_W)
 
 int socket_waitfd(p_socket ps, int sw, p_timeout tm) {
     int ret;

--- a/src/wsocket.h
+++ b/src/wsocket.h
@@ -30,4 +30,9 @@ typedef t_socket *p_socket;
 #define AI_NUMERICSERV (0)
 #endif
 
+#define WAITFD_R        1
+#define WAITFD_W        2
+#define WAITFD_E        4
+#define WAITFD_C        (WAITFD_E|WAITFD_W)
+
 #endif /* WSOCKET_H */


### PR DESCRIPTION
Hi everyone,

This is a quite large pull request and it deserves some explanation. It is one of two pull requests (the [second one going to luasec](https://github.com/brunoos/luasec/pull/5)) which shall fix the issue of duplication of code in luasocket and luasec and the issues which arise from using a dynamically linked version of luasec (see also [Prosody bug #28](https://code.google.com/p/lxmppd/issues/detail?id=298)).

The first commit publishes the WAITFD_\* constants, which are used by luasec at some places and is part of the modifications luasec makes to the luasocket headers.

The second one is larger and possibly more disputable. It publishes a whole bunch, probably more than strictly needed, of functions using the LUASOCKET_API define. This is required to allow luasec to find the symbols if loaded into the same process.

Together with the pull request which will be issued in a minute to luasec, this could improve user experience, especially on redhat systems, where the libraries are dynamically linked, a lot.

If you have any suggestions for improvements or any kind of critique, please let me know so that we can fix that quickly.

best regards,
Jonas
