### PR TITLE
Added a fix for properly reporting CONNRESET.

### DIFF
--- a/src/wsocket.c
+++ b/src/wsocket.c
@@ -262,6 +262,7 @@ int socket_recv(p_socket ps, char *data, size_t count, size_t *got,
         if (err != WSAEWOULDBLOCK) {
             if (err != WSAECONNRESET || prev == WSAECONNRESET) return err;
             prev = err;
+            continue;
         }
         if ((err = socket_waitfd(ps, WAITFD_R, tm)) != IO_DONE) return err;
     }
@@ -291,6 +292,7 @@ int socket_recvfrom(p_socket ps, char *data, size_t count, size_t *got,
         if (err != WSAEWOULDBLOCK) {
             if (err != WSAECONNRESET || prev == WSAECONNRESET) return err;
             prev = err;
+            continue;
         }
         if ((err = socket_waitfd(ps, WAITFD_R, tm)) != IO_DONE) return err;
     }


### PR DESCRIPTION
This patch fixes an issue with the current version of the library that doesn't properly report CONNRESET to the application.

This issue is 100% reproducible in my application, even though I failed to create a simple script to demonstrate it on. The issue happens when the process on the other side of the connection is killed. I bisected this issue to the commit 734cc23e1f with the following comment:

```
I am a bit unsure about the UDP fix, because it may affect
TCP as well. On UDP sockets, when a sendto fails, the next
receive/receivefrom fails with CONNRESET. I changed
sock_recv/sock_recvfrom in wsocket.c to skip the CONNRESET
from the recv/recvfrom, hoping that if the socket is TCP,
sock_waitfd will get the CONNRESET again. The tests pass,
but this should be tested more thoroughly.
```

Also a very relevant discussion on the related pull request [here](https://github.com/diegonehab/luasocket/pull/39#issuecomment-18508959).

By reviewing the symptoms I see, this is exactly what happens: my application that uses `copas` doesn't get "nil, closed" event, only sees "nil, timeout", and continues 'selecting' the socket that has already been closed, thus never returning the control.

This issue is fixed in the commit by changing

``` c
if (err != WSAEWOULDBLOCK && err != WSAECONNRESET) return err;
```

to 

``` c
if (err != WSAEWOULDBLOCK) return err;
```

or by adding `continue` statement in the current HEAD as I did in the patch.

I get all the tests passing with these changes and my application is working correctly.

I can provide instructions on how to test this using my app; it may only take 3-5m or so to set it up.
