### PR TITLE
Socker:receive("l") without asterisk, `L` option

### DIFF
--- a/docs/tcp.html
+++ b/docs/tcp.html
@@ -366,7 +366,8 @@ client:<b>receive(</b>[pattern [, prefix [, maxsize]]]<b>)</b>
 
 <p class="description">
 Reads data from a client object, according to the specified <em>read
-pattern</em>.  Patterns follow the Lua file I/O format, and the difference in performance between all patterns is negligible.
+pattern</em>.  Patterns follow the Lua file I/O format, and the difference in
+performance between all patterns is negligible.
 </p>
 
 <p class="parameters">
@@ -374,13 +375,17 @@ pattern</em>.  Patterns follow the Lua file I/O format, and the difference in pe
 </p>
 
 <ul>
-<li> '<tt>*a</tt>':  reads from  the  socket  until the  connection  is
+<li> '<tt>a</tt>':  reads from  the  socket  until the  connection  is
 closed. No end-of-line translation is performed;</li>
-<li> '<tt>*l</tt>':  reads a line of  text from the socket.  The line is
+<li> '<tt>l</tt>':  reads a line of  text from the socket.  The line is
 terminated by a  LF character (ASCII&nbsp;10), optionally  preceded by a
 CR character (ASCII&nbsp;13). The CR and LF characters are not included in
-the returned line. In fact, <em>all</em> CR characters are
-ignored by the pattern. This is the default pattern;</li>
+the returned line. CR characters not at the end of the line are still included.
+This is the default pattern;</li>
+<li> '<tt>L</tt>':  reads a line of  text from the socket.  The line is
+terminated by a  LF character (ASCII&nbsp;10), optionally  preceded by a
+CR character (ASCII&nbsp;13). The CR and LF characters are kept in the returned
+line.</li>
 <li> <tt>number</tt>:  causes the  method to read  a specified <tt>number</tt>
 of bytes from the socket.</li>
 </ul>

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -279,26 +279,41 @@ static int recvall(p_buffer buf, luaL_Buffer *b, size_t budget) {
 * budget payload bytes succeeds while budget+1 reports oversized. A timeout
 * or close with the payload exactly at the cap and no terminator yet also
 * resolves to oversized, never to timeout/closed.
+* Internal CRs are retained.
 \*-------------------------------------------------------------------------*/
 static int recvline(p_buffer buf, luaL_Buffer *b, size_t budget) {
     int err = IO_DONE;
     size_t total = 0;
+    char hasprevch = 0;
+    char prevch;
     while (err == IO_DONE) {
         size_t count, pos; const char *data;
         err = buffer_get(buf, &data, &count, BUF_SIZE);
         pos = 0;
         while (pos < count && data[pos] != '\n') {
-            /* we ignore all \r's -- they are consumed but never counted */
-            if (data[pos] != '\r') {
+            /* we delay all the characters an iteration so that \r can be skipped */
+            if (hasprevch) {
                 if (budget && total == budget) {
                     /* leave the offending byte in the buffer for the next call */
-                    buffer_skip(buf, pos);
+                    buffer_skip(buf, pos - 1);
                     return BUF_OVERSIZED;
                 }
-                luaL_addchar(b, data[pos]);
+                luaL_addchar(b, prevch);
                 total++;
             }
+            prevch = data[pos];
+            hasprevch = 1;
             pos++;
+        }
+        if (hasprevch && prevch != '\r') {
+            hasprevch = 0;
+            if (budget && total == budget) {
+                /* leave the offending byte in the buffer for the next call */
+                buffer_skip(buf, pos - 1);
+                return BUF_OVERSIZED;
+            }
+            luaL_addchar(b, prevch);
+            total++;
         }
         if (pos < count) { /* found '\n' */
             buffer_skip(buf, pos+1); /* skip '\n' too */

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -9,7 +9,7 @@
 * Internal function prototypes
 \*=========================================================================*/
 static int recvraw(p_buffer buf, size_t wanted, luaL_Buffer *b);
-static int recvline(p_buffer buf, luaL_Buffer *b, size_t budget);
+static int recvline(p_buffer buf, luaL_Buffer *b, size_t budget, int chop);
 static int recvall(p_buffer buf, luaL_Buffer *b, size_t budget);
 static int buffer_get(p_buffer buf, const char **data, size_t *count, size_t wanted);
 static void buffer_skip(p_buffer buf, size_t count);
@@ -133,7 +133,7 @@ int buffer_meth_receive(lua_State *L, p_buffer buf) {
         const char *p = luaL_optstring(L, 2, "l");
         if (p[0] == '*') p++;
         recvpat = p[0];
-        luaL_argcheck(L, recvpat == 'l' || recvpat == 'a',
+        luaL_argcheck(L, recvpat == 'l' || recvpat == 'a' || recvpat == 'L',
                       2, "invalid receive pattern");
     }
     if (!lua_isnoneornil(L, 4)) {
@@ -159,7 +159,8 @@ int buffer_meth_receive(lua_State *L, p_buffer buf) {
     luaL_addlstring(&b, part, size);
     /* receive new patterns */
     if (!numeric) {
-        if (recvpat == 'l') err = recvline(buf, &b, budget);
+        if (recvpat == 'l') err = recvline(buf, &b, budget, 1);
+        else if (recvpat == 'L') err = recvline(buf, &b, budget, 0);
         else err = recvall(buf, &b, budget);
     /* get a fixed number of bytes (minus what was already partially
      * received) */
@@ -283,7 +284,7 @@ static int recvall(p_buffer buf, luaL_Buffer *b, size_t budget) {
 * resolves to oversized, never to timeout/closed.
 * Internal CRs are retained.
 \*-------------------------------------------------------------------------*/
-static int recvline(p_buffer buf, luaL_Buffer *b, size_t budget) {
+static int recvline(p_buffer buf, luaL_Buffer *b, size_t budget, int chop) {
     int err = IO_DONE;
     size_t total = 0;
     char hasprevch = 0;
@@ -307,7 +308,7 @@ static int recvline(p_buffer buf, luaL_Buffer *b, size_t budget) {
             hasprevch = 1;
             pos++;
         }
-        if (hasprevch && prevch != '\r') {
+        if (hasprevch && (prevch != '\r' || !chop)) {
             hasprevch = 0;
             if (budget && total == budget) {
                 /* leave the offending byte in the buffer for the next call */
@@ -318,6 +319,14 @@ static int recvline(p_buffer buf, luaL_Buffer *b, size_t budget) {
             total++;
         }
         if (pos < count) { /* found '\n' */
+            if (!chop) {
+                if (budget && total == budget) {
+                    /* leave the offending byte in the buffer for the next call */
+                    buffer_skip(buf, pos);
+                    return BUF_OVERSIZED;
+                }
+                luaL_addchar(b, '\n');
+            }
             buffer_skip(buf, pos+1); /* skip '\n' too */
             break; /* we are done */
         } else /* reached the end of the buffer */

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -121,6 +121,7 @@ int buffer_meth_receive(lua_State *L, p_buffer buf) {
     size_t budget = 0;  /* 0 == unlimited */
     int numeric = lua_isnumber(L, 2);
     const char *part = luaL_optlstring(L, 3, "", &size);
+    char recvpat;
 
     /* ---- validation: must precede timeout_markstart() and any I/O ---- */
     if (numeric) {
@@ -129,8 +130,10 @@ int buffer_meth_receive(lua_State *L, p_buffer buf) {
             "invalid receive pattern");
         wanted = (size_t) n;
     } else {
-        const char *p = luaL_optstring(L, 2, "*l");
-        luaL_argcheck(L, p[0] == '*' && (p[1] == 'l' || p[1] == 'a'),
+        const char *p = luaL_optstring(L, 2, "l");
+        if (p[0] == '*') p++;
+        recvpat = p[0];
+        luaL_argcheck(L, recvpat == 'l' || recvpat == 'a',
                       2, "invalid receive pattern");
     }
     if (!lua_isnoneornil(L, 4)) {
@@ -156,8 +159,7 @@ int buffer_meth_receive(lua_State *L, p_buffer buf) {
     luaL_addlstring(&b, part, size);
     /* receive new patterns */
     if (!numeric) {
-        const char *p= luaL_optstring(L, 2, "*l");
-        if (p[0] == '*' && p[1] == 'l') err = recvline(buf, &b, budget);
+        if (recvpat == 'l') err = recvline(buf, &b, budget);
         else err = recvall(buf, &b, budget);
     /* get a fixed number of bytes (minus what was already partially
      * received) */

--- a/test/testclnt.lua
+++ b/test/testclnt.lua
@@ -294,7 +294,15 @@ function empty_connect()
         pass("ok")
         data = socket.connect(host, port)
     else
-        pass("gethostbyname returns localhost on empty string...")
+        local peer = data:getpeername()
+        if peer == '127.0.0.1' or peer == '::1' then
+            pass("gethostbyname returns localhost on empty string...")
+        else
+            -- it bound to the address of the computer on the local network
+            -- which won't necessarily be able to communicate depending on firewall
+            pass("gethostbyname returns local computer on empty string...")
+            data = socket.connect(host, port)
+        end
     end
 end
 

--- a/test/testclnt.lua
+++ b/test/testclnt.lua
@@ -200,6 +200,32 @@ remote "data:send(str)"
 end
 
 ------------------------------------------------------------------------
+function test_linebackforth(text, lineending)
+    local sent, back, err
+remote "str = data:receive()"
+    sent, err = data:send(text .. lineending)
+    if err then fail(err) end
+remote "data:send(str ..'\\r\\n')"
+    back, err = data:receive()
+    if err then fail(err) end
+    if text == back then pass("linesbf match")
+    else fail("linesbf don't match") end
+end
+
+------------------------------------------------------------------------
+function test_linebackforthL(text)
+    local sent, back, err
+remote "str = data:receive('L')"
+    sent, err = data:send(text)
+    if err then fail(err) end
+remote "data:send(str)"
+    back, err = data:receive('L')
+    if err then fail(err) end
+    if text == back then pass("linesbf match")
+    else fail("linesbf don't match") end
+end
+
+------------------------------------------------------------------------
 function test_totaltimeoutreceive(len, tm, sl)
     reconnect()
     local str, err, partial
@@ -958,6 +984,20 @@ test_raw(4091)
 test_raw(200)
 test_raw(17)
 test_raw(1)
+
+test("line endings")
+test_linebackforth("test data", "\n")
+test_linebackforth("test data", "\r\n")
+test_linebackforth("test data\r", "\r\n") -- a \r at the end can be kept
+test_linebackforth("\rtest\rthis", "\n")
+test_linebackforth("\rtest\rthis", "\r\n")
+
+test("line endings with recv(L)")
+test_linebackforthL("test data\n")
+test_linebackforthL("test data\r\n")
+test_linebackforthL("test data\r\r\n")
+test_linebackforthL("\rtest\rthis\n")
+test_linebackforthL("\rtest\rthis\r\n")
 
 test("non-blocking transfer")
 test_nonblocking(1)


### PR DESCRIPTION
This pull request allows users to call `socket:receive()` without the parameter having to start with an asterisk. It also adds the `L` option, which includes the end of line marker.