### PR TITLE
Remove LUASOCKET_INET_PTON from *.rockspec

### DIFF
--- a/rockspec/luasocket-3.0rc2-1.rockspec
+++ b/rockspec/luasocket-3.0rc2-1.rockspec
@@ -34,7 +34,6 @@ local function make_plat(plat)
     },
     mingw32 = {
       "LUASOCKET_DEBUG",
-      "LUASOCKET_INET_PTON",
       "WINVER=0x0501"
     }
   }

--- a/rockspec/luasocket-scm-2.rockspec
+++ b/rockspec/luasocket-scm-2.rockspec
@@ -34,7 +34,6 @@ local function make_plat(plat)
     },
     mingw32 = {
       "LUASOCKET_DEBUG",
-      "LUASOCKET_INET_PTON",
       "WINVER=0x0501"
     }
   }

--- a/src/inet.h
+++ b/src/inet.h
@@ -22,6 +22,12 @@
 #define LUASOCKET_INET_ATON
 #endif
 
+/* MSVC and MinGW provides "#define InetPtonA inet_pton" when
+ * inet_pton() is available. */
+#if !defined(LUASOCKET_INET_PTON) && defined(_WIN32) && !defined(InetPtonA)
+#define LUASOCKET_INET_PTON
+#endif
+
 #ifndef _WIN32
 #pragma GCC visibility push(hidden)
 #endif
@@ -45,7 +51,6 @@ int inet_aton(const char *cp, struct in_addr *inp);
 #endif
 
 #ifdef LUASOCKET_INET_PTON
-const char *inet_ntop(int af, const void *src, char *dst, socklen_t cnt);
 int inet_pton(int af, const char *src, void *dst);
 #endif
 


### PR DESCRIPTION
Recent MinGW provides inet_pton(). There is our inet_pton()
implementation in src/inet.c. Our inet_pton() is declared in
src/inet.h but the declaration causes the following build error:

    gcc -O2 -fPIC -c -o src/luasocket.o -IC://msys64/mingw64/include/luajit-2.0 src/luasocket.c -DLUA_COMPAT_APIINTCASTS -DLUASOCKET_DEBUG -DLUASOCKET_INET_PTON -DWINVER=0x0501 -DLUASOCKET_API=__declspec(dllexport) -DMIME_API=__declspec(dllexport)

    src/inet.h:46:13: error: conflicting types for 'inet_ntop'
       46 | const char *inet_ntop(int af, const void *src, char *dst, socklen_t cnt);
          |             ^~~~~~~~~

    In file included from src/wsocket.h:12,
                     from src/socket.h:18,
                     from src/inet.h:18,
                     from src/luasocket.c:30:
    C:/msys64/mingw64/x86_64-w64-mingw32/include/ws2tcpip.h:451:35: note: previous declaration of 'inet_ntop' was
     here
      451 | WINSOCK_API_LINKAGE LPCSTR WSAAPI InetNtopA(INT Family, LPCVOID pAddr, LPSTR pStringBuf, size_t StringBufSize);
          |                                   ^~~~~~~~~

    In file included from src/luasocket.c:30:
    src/inet.h:47:5: warning: 'inet_pton' redeclared without dllimport attribute: previous dllimport ignored [-Wattributes]
       47 | int inet_pton(int af, const char *src, void *dst);
          |     ^~~~~~~~~

We already know that we don't need our inet_pton() for recent MinGW.
78a1657c7db5510ba66f8d4491f1e8e7370c5943 (#300) removed
-DLUASOCKET_INET_PTON but LUASOCKET_INET_PTON in *.rockspec wasn't
removed.

It causes "luarocks install luasocket" for MinGW causes the above
build error.