### PR TITLE
ci: add Visual C++ and MinGW jobs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,121 @@
+name: Windows
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  visual-studio:
+    name: Visual Studio ${{ matrix.vs-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        vs-version:
+          - 2019
+          - 2017
+        include:
+          - cmake-architecture: x64
+            cmake-generator: Visual Studio 16 2019
+            runs-on: windows-2019
+            vs-version: 2019
+          - cmake-generator: Visual Studio 15 2017 Win64
+            runs-on: windows-2016
+            vs-version: 2017
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - name: Disable crash dialog
+        run: |
+          reg add "HKCU\SOFTWARE\Microsoft\Windows\Windows Error Reporting" `
+            /v DontShowUI `
+            /t REG_DWORD `
+            /d 1 `
+            /f
+      - uses: actions/checkout@v2
+      - name: Set environment variables
+        run: |
+          Write-Output "::set-env name=CMAKE_BUILD_PARALLEL_LEVEL::${Env:NUMBER_OF_PROCESSORS}"
+
+          $VC_PREFIX = "C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs-version }}\Enterprise\VC"
+          Write-Output "::set-env name=VC_PREFIX::${VC_PREFIX}"
+
+          $INSTALL_FOLDER = "${Env:GITHUB_WORKSPACE}\install"
+          Write-Output "::set-env name=INSTALL_FOLDER::${INSTALL_FOLDER}"
+
+          $LUA = "${INSTALL_FOLDER}\bin\lua.exe"
+          Write-Output "::set-env name=LUA::${LUA}"
+
+          $LUASOCKET_ROCKSPEC = $(Get-ChildItem rockspec -Exclude "*scm*").FullName
+          Write-Output "::set-env name=LUASOCKET_ROCKSPEC::${LUASOCKET_ROCKSPEC}"
+      - name: Install Lua
+        shell: cmd
+        run: |
+          call "%VC_PREFIX%\Auxiliary\Build\vcvarsall.bat" x64
+          mkdir lua-build
+          set CMAKE_ARGS=-S ci\lua
+          set CMAKE_ARGS=%CMAKE_ARGS% -B lua-build
+          if not "${{ matrix.cmake-architecture }}" == "" (
+            set CMAKE_ARGS=%CMAKE_ARGS% -A ${{ matrix.cmake-architecture }}
+          )
+          set CMAKE_ARGS=%CMAKE_ARGS% -G "${{ matrix.cmake-generator }}"
+          set CMAKE_ARGS=%CMAKE_ARGS% "-DCMAKE_INSTALL_PREFIX=%INSTALL_FOLDER%"
+          cmake %CMAKE_ARGS%
+          cmake --build lua-build --config RelWithDebInfo
+          cmake --build lua-build --config RelWithDebInfo --target Install
+      - name: Install LuaRocks
+        run: |
+          $LUAROCKS_VERSION = "3.3.1"
+          $LUAROCKS_ARCHIVE_BASE = "luarocks-${LUAROCKS_VERSION}-windows-64"
+          Invoke-WebRequest `
+            -Uri "http://luarocks.github.io/luarocks/releases/${LUAROCKS_ARCHIVE_BASE}.zip" `
+            -OutFile "${LUAROCKS_ARCHIVE_BASE}.zip"
+          Expand-Archive `
+            -DestinationPath . `
+            "${LUAROCKS_ARCHIVE_BASE}.zip"
+
+          $LUAROCKS = "${Env:GITHUB_WORKSPACE}\${LUAROCKS_ARCHIVE_BASE}\luarocks.exe"
+          Write-Output "::set-env name=LUAROCKS::${LUAROCKS}"
+      - name: Prepare LuaRocks
+        shell: cmd
+        run: |
+          call "%VC_PREFIX%\Auxiliary\Build\vcvarsall.bat" x64
+          %LUAROCKS% --lua-dir %INSTALL_FOLDER% path > luarocks.path.bat
+      - name: Install LuaSocket
+        shell: cmd
+        run: |
+          call "%VC_PREFIX%\Auxiliary\Build\vcvarsall.bat" x64
+          %LUAROCKS% --lua-dir %INSTALL_FOLDER% make %LUASOCKET_ROCKSPEC%
+      - name: Test LuaSocket
+        shell: cmd
+        run: |
+          call "%VC_PREFIX%\Auxiliary\Build\vcvarsall.bat" x64
+          call luarocks.path.bat
+          cd test
+          %LUA% hello.lua
+
+  mingw:
+    name: MinGW
+    runs-on: windows-2019
+    steps:
+      - name: Disable crash dialog
+        run: |
+          reg add "HKCU\SOFTWARE\Microsoft\Windows\Windows Error Reporting" `
+            /v DontShowUI `
+            /t REG_DWORD `
+            /d 1 `
+            /f
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-lua51-luarocks
+      - name: Install LuaSocket
+        shell: msys2 {0}
+        run: |
+          rm rockspec/*-scm-*.rockspec || :
+          luarocks make rockspec/*.rockspec
+      - name: Test LuaSocket
+        shell: msys2 {0}
+        run: |
+          cd test
+          lua5.1.exe hello.lua

--- a/ci/lua/CMakeLists.txt
+++ b/ci/lua/CMakeLists.txt
@@ -1,0 +1,151 @@
+# GitHub Actions ships CMake 3.18.0:
+#  * https://github.com/actions/virtual-environments/blob/main/images/win/Windows2016-Readme.md#tools
+#  * https://github.com/actions/virtual-environments/blob/main/images/win/Windows2016-Readme.md#tools
+cmake_minimum_required(VERSION 3.14.0)
+
+set(LUA_VERSION "5.4.0" CACHE STRING "Lua version to be built")
+
+project(lua
+  VERSION ${LUA_VERSION}
+  HOMEPAGE_URL "https://www.lua.org/"
+  LANGUAGES C)
+
+include(GNUInstallDirs)
+
+set(LUA_ARCHIVE_BASE "lua-${LUA_VERSION}")
+set(LUA_ARCHIVE_NAME "${LUA_ARCHIVE_BASE}.tar.gz")
+if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${LUA_ARCHIVE_NAME}")
+  message("Downloading Lua ${LUA_VERSION}...")
+  set(LUA_ARCHIVE_URL "https://www.lua.org/ftp/${LUA_ARCHIVE_NAME}")
+  file(DOWNLOAD
+    ${LUA_ARCHIVE_URL}
+    "${CMAKE_CURRENT_BINARY_DIR}/${LUA_ARCHIVE_NAME}"
+    SHOW_PROGRESS
+    STATUS LUA_DOWNLOAD_STATUS)
+  list(GET LUA_DOWNLOAD_STATUS 0 LUA_DOWNLOAD_STATUS_CODE)
+  if(NOT ${LUA_DOWNLOAD_STATUS_CODE} EQUAL 0)
+    message(FATAL_ERROR
+      "Failed to download Lua source: ${LUA_ARCHIVE_URL}: ${LUA_DOWNLOAD_STATUS}")
+  endif()
+  execute_process(COMMAND ${CMAKE_COMMAND} -E "tar" "xf" ${LUA_ARCHIVE_NAME}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
+string(REGEX REPLACE
+  "^([0-9]+)\\.([0-9]+)\\..*$"
+  "\\1\\2"
+  LUA_DLL_VERSION
+  ${LUA_VERSION})
+
+if(${LUA_VERSION} VERSION_LESS "5.5.0")
+  add_compile_definitions("LUA_COMPAT_5_3")
+elseif(${LUA_VERSION} VERSION_LESS "5.4.0")
+  add_compile_definitions("LUA_COMPAT_5_2")
+endif()
+if(WIN32)
+  add_compile_definitions("LUA_BUILD_AS_DLL")
+endif()
+
+set(LUA_SOURCE_BASE ${CMAKE_CURRENT_BINARY_DIR}/${LUA_ARCHIVE_BASE}/src)
+set(LIBLUA_CORE_SOURCES
+  ${LUA_SOURCE_BASE}/lapi.c
+  ${LUA_SOURCE_BASE}/lcode.c
+  ${LUA_SOURCE_BASE}/lctype.c
+  ${LUA_SOURCE_BASE}/ldebug.c
+  ${LUA_SOURCE_BASE}/ldo.c
+  ${LUA_SOURCE_BASE}/ldump.c
+  ${LUA_SOURCE_BASE}/lfunc.c
+  ${LUA_SOURCE_BASE}/lgc.c
+  ${LUA_SOURCE_BASE}/llex.c
+  ${LUA_SOURCE_BASE}/lmem.c
+  ${LUA_SOURCE_BASE}/lobject.c
+  ${LUA_SOURCE_BASE}/lopcodes.c
+  ${LUA_SOURCE_BASE}/lparser.c
+  ${LUA_SOURCE_BASE}/lstate.c
+  ${LUA_SOURCE_BASE}/lstring.c
+  ${LUA_SOURCE_BASE}/ltable.c
+  ${LUA_SOURCE_BASE}/ltm.c
+  ${LUA_SOURCE_BASE}/lundump.c
+  ${LUA_SOURCE_BASE}/lvm.c
+  ${LUA_SOURCE_BASE}/lzio.c)
+set(LIBLUA_LIB_SOURCES
+  ${LUA_SOURCE_BASE}/lauxlib.c
+  ${LUA_SOURCE_BASE}/lbaselib.c
+  ${LUA_SOURCE_BASE}/lcorolib.c
+  ${LUA_SOURCE_BASE}/ldblib.c
+  ${LUA_SOURCE_BASE}/liolib.c
+  ${LUA_SOURCE_BASE}/lmathlib.c
+  ${LUA_SOURCE_BASE}/loadlib.c
+  ${LUA_SOURCE_BASE}/loslib.c
+  ${LUA_SOURCE_BASE}/lstrlib.c
+  ${LUA_SOURCE_BASE}/ltablib.c
+  ${LUA_SOURCE_BASE}/lutf8lib.c
+  ${LUA_SOURCE_BASE}/linit.c)
+set(LIBLUA_SOURCES ${LIBLUA_CORE_SOURCES} ${LIBLUA_LIB_SOURCES})
+add_library(liblua_shared SHARED ${LIBLUA_SOURCES})
+if(NOT WIN32)
+  add_library(liblua_static STATIC ${LIBLUA_SOURCES})
+endif()
+if(NOT WIN32)
+  target_link_libraries(liblua_shared m)
+  target_link_libraries(liblua_static m)
+endif()
+if(WIN32)
+  set_target_properties(liblua_shared PROPERTIES
+    OUTPUT_NAME "lua${LUA_DLL_VERSION}")
+else()
+  set_target_properties(liblua_shared
+    PROPERTIES OUTPUT_NAME "lua")
+  set_target_properties(liblua_static
+    PROPERTIES OUTPUT_NAME "lua")
+endif()
+install(TARGETS liblua_shared
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+if(NOT WIN32)
+  install(TARGETS liblua_static
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
+if(MSVC)
+  install(FILES $<TARGET_PDB_FILE:liblua_shared>
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    OPTIONAL)
+endif()
+
+set(LUA_SOURCES ${LUA_SOURCE_BASE}/lua.c)
+add_executable(lua ${LUA_SOURCES})
+if(WIN32)
+  target_link_libraries(lua liblua_shared)
+else()
+  target_link_libraries(lua liblua_static)
+endif()
+install(TARGETS lua DESTINATION ${CMAKE_INSTALL_BINDIR})
+if(MSVC)
+  install(FILES $<TARGET_PDB_FILE:lua>
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    OPTIONAL)
+endif()
+
+set(LUAC_SOURCES ${LUA_SOURCE_BASE}/luac.c)
+if(WIN32)
+  add_executable(luac ${LUAC_SOURCES} ${LIBLUA_SOURCES})
+else()
+  target_link_libraries(luac liblua_static)
+endif()
+install(TARGETS luac DESTINATION ${CMAKE_INSTALL_BINDIR})
+if(MSVC)
+  install(FILES $<TARGET_PDB_FILE:luac>
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    OPTIONAL)
+endif()
+
+install(FILES
+  ${LUA_SOURCE_BASE}/lua.h
+  ${LUA_SOURCE_BASE}/luaconf.h
+  ${LUA_SOURCE_BASE}/lualib.h
+  ${LUA_SOURCE_BASE}/lauxlib.h
+  ${LUA_SOURCE_BASE}/lua.hpp
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
https://github.com/kou/luasocket/actions/runs/196950032 is a result of this.

MinGW job is failed because #312 isn't included. If we have #312, the job is passed: https://github.com/kou/luasocket/actions/runs/196944672

This uses Lua 5.4 for Visual C++ and Lua 5.1 for MinGW.

This has `CMakeLists.txt` to build Lua 5.4 with Visual C++. It's written me from scratch because there isn't the official Lua build system for Visual C++. There are some projects that writes `CMakeLists.txt` such as https://github.com/LuaDist/lua . I searches them when I'm writing this. It seems that the official Lua will not support CMake because there is no consensus to use CMake. I searched lua-users mailing list: http://lua-users.org/cgi-bin/namazu.cgi?query=cmake+visual&idxname=lua-l&max=20&result=normal&sort=date%3Alate

Should we use other `CMakeLists.txt` implementation rather than the `CMakeLIsts.txt` in this pull request? I think that the `CMakeLists.txt` in this pull request is simple enough to maintain.

`test/hello.lua` is only used for testing. We can add more tests as follow-up tasks.