### PR TITLE
http.lua: set transfer-encoding if source and no content-length

### DIFF
--- a/src/http.lua
+++ b/src/http.lua
@@ -283,6 +283,13 @@ local function adjustrequest(reqt)
     nreqt.uri = reqt.uri or adjusturi(nreqt)
     -- adjust headers in request
     nreqt.headers = adjustheaders(nreqt)
+    if nreqt.source
+        and not nreqt.headers["content-length"]
+        and not nreqt.headers["transfer-encoding"]
+    then
+        nreqt.headers["transfer-encoding"] = "chunked"
+    end
+
     -- ajust host and port if there is a proxy
     nreqt.host, nreqt.port = adjustproxy(nreqt)
     return nreqt


### PR DESCRIPTION
If a source is specified without a content-length header, LuaSocket
sends the data in the chunked transfer coding; however, it doesn't set
the transfer-encoding header.  While I recognize that the user can set
this manually, this is a gotcha that has caught me multiple times.

RFC7230, section 3.3.3
  (https://tools.ietf.org/html/rfc7230#section-3.3.3)
is clear about this; if neither content-length nor transfer-encoding
chunked are specified, the request message body length is zero.  While
some servers may ignore this, I have encountered several that follow
the RFC in this regard, most recently golang's net/http.