### PR TITLE
Fix argumentless receive call on Lua 5.4 #331

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -113,7 +113,9 @@ int buffer_meth_receive(lua_State *L, p_buffer buf) {
     luaL_buffinit(L, &b);
     luaL_addlstring(&b, part, size);
     /* receive new patterns */
-    if (!lua_isnumber(L, 2)) {
+    if(top < 2){
+        err = recvline(buf, &b);
+    } else if (!lua_isnumber(L, 2)) {
         const char *p= luaL_optstring(L, 2, "*l");
         if (p[0] == '*' && p[1] == 'l') err = recvline(buf, &b);
         else if (p[0] == '*' && p[1] == 'a') err = recvall(buf, &b);


### PR DESCRIPTION
It seems that on Lua 5.4 when calling conn:receive() without arguments,
a lightuserdata related to the luaL_Buffer ends up in position 2. Since
this is not a number, luaL_optstring() complains.