### PR TITLE
fix(docs) references to some constants added

### DIFF
--- a/doc/socket.html
+++ b/doc/socket.html
@@ -255,7 +255,8 @@ changed status.
 
 <p class="note">
 <b>Note:</b> <tt>select</tt> can monitor a limited number
-of sockets, as defined by the constant <tt>socket._SETSIZE</tt>. This
+of sockets, as defined by the constant <a href="#setsize">
+<tt>socket._SETSIZE</tt></a>. This
 number may be as high as 1024 or as low as 64 by default,
 depending on the system. It is usually possible to change this
 at compile time. Invoking <tt>select</tt> with a larger
@@ -410,7 +411,8 @@ socket.<b>_SOCKETINVALID</b>
 </p>
 
 <p class="description">
-The OS value for an invalid socket.
+The OS value for an invalid socket. This can be used with <a href="tcp.html#getfd">
+<tt>tcp:getfd</tt></a> and <a href="tcp.html#setfd"><tt>tcp:setfd</tt></a> methods.
 </p>
 
 <!-- try ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->

--- a/doc/tcp.html
+++ b/doc/tcp.html
@@ -209,7 +209,9 @@ Returns the underling socket descriptor or handle associated to the object.
 </p>
 
 <p class="return">
-The descriptor or handle. In case the object has been closed, the return will be -1.
+The descriptor or handle. In case the object has been closed, the return value
+will be -1. For an invalid socket it will be <a href="socket.html#socketinvalid">
+<tt>_SOCKETINVALID</tt></a>.
 </p>
 
 <p class="note">
@@ -611,7 +613,9 @@ server:<b>setfd(</b>fd<b>)</b>
 </p>
 
 <p class="description">
-Sets the underling socket descriptor or handle associated to the object. The current one is simply replaced, not closed, and no other change to the object state is made.
+Sets the underling socket descriptor or handle associated to the object. The current one
+is simply replaced, not closed, and no other change to the object state is made.
+To set it as invalid use <a href="socket.html#socketinvalid"><tt>_SOCKETINVALID</tt></a>.
 </p>
 
 <p class="return">


### PR DESCRIPTION
this is on top of the html linter PR to prevent merge conflicts, so merge that one (#358) first.

This PR documents fixes already made since #134 

