### PR TITLE
ci: Utilize new upstream Luacheck Action

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -7,13 +7,7 @@ jobs:
   luacheck:
     runs-on: ubuntu-20.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Setup ‘lua’
-      uses: leafo/gh-actions-lua@v9
-    - name: Setup ‘luarocks’
-      uses: leafo/gh-actions-luarocks@v4
-    - name: Setup ‘luacheck’
-      run: luarocks install luacheck
-    - name: Run ‘luacheck’ linter
-      run: luacheck .
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Luacheck
+        uses: lunarmodules/luacheck@v0


### PR DESCRIPTION
As of v0.26.0, the Luacheck repository is enabled to run *as* a GH
Action so there is no need to install Lua, LuaRocks, then the linter,
etc. Just one `uses:`.