### PR TITLE
Fix #373

### DIFF
--- a/src/ltn12.lua
+++ b/src/ltn12.lua
@@ -15,6 +15,7 @@ local select = select
 
 local _M = {}
 if module then -- heuristic for exporting a global package table
+    ---@diagnostic disable-next-line:lowercase-global
     ltn12 = _M  -- luacheck: ignore
 end
 local filter,source,sink,pump = {},{},{},{}


### PR DESCRIPTION
Adds and EmmyLua annotation to skip diagnostics on the next line. Here is some more [info](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#diagnostic).