### PR TITLE
Add support for TCP_DEFER_ACCEPT

### DIFF
--- a/docs/tcp.html
+++ b/docs/tcp.html
@@ -485,6 +485,8 @@ disables the Nagle's algorithm for the connection;</li>
 
 <li> '<tt>tcp-keepintvl</tt>': value for <tt>TCP_KEEPINTVL</tt> Linux only!!</li>
 
+<li> '<tt>tcp-defer-accept</tt>': value for <tt>TCP_DEFER_ACCEPT</tt> Linux only!!</li>
+
 <li> '<tt>ipv6-v6only</tt>':
 Setting this option to <tt>true</tt> restricts an <tt>inet6</tt> socket to
 sending and receiving only IPv6 packets.</li>

--- a/src/options.c
+++ b/src/options.c
@@ -191,6 +191,15 @@ int opt_set_send_buf_size(lua_State *L, p_socket ps)
 }
 
 /*------------------------------------------------------*/
+
+#ifdef TCP_DEFER_ACCEPT
+int opt_set_tcp_defer_accept(lua_State *L, p_socket ps)
+{
+    return opt_setint(L, ps, IPPROTO_TCP, TCP_DEFER_ACCEPT);
+}
+#endif
+
+/*------------------------------------------------------*/
 int opt_set_ip6_unicast_hops(lua_State *L, p_socket ps)
 {
   return opt_setint(L, ps, IPPROTO_IPV6, IPV6_UNICAST_HOPS);

--- a/src/options.h
+++ b/src/options.h
@@ -49,6 +49,10 @@ int opt_set_tcp_keepintvl(lua_State *L, p_socket ps);
 int opt_get_tcp_keepintvl(lua_State *L, p_socket ps);
 #endif
 
+#ifdef TCP_DEFER_ACCEPT
+int opt_set_tcp_defer_accept(lua_State *L, p_socket ps);
+#endif
+
 int opt_set_keepalive(lua_State *L, p_socket ps);
 int opt_get_keepalive(lua_State *L, p_socket ps);
 

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -109,6 +109,9 @@ static t_opt optset[] = {
     {"linger",      opt_set_linger},
 	{"recv-buffer-size",     opt_set_recv_buf_size},
 	{"send-buffer-size",     opt_set_send_buf_size},
+#ifdef TCP_DEFER_ACCEPT
+    {"tcp-defer-accept", opt_set_tcp_defer_accept},
+#endif
     {NULL,          NULL}
 };
 


### PR DESCRIPTION
This makes it so that a listening socket does not become readable for
accept() until a connection has been fully established *and* started
sending something, thus the program doesn't have to wait for the first
data. This only makes sense for client-speaks-first protocols.