### PR TITLE
Add windows patch to rockspec

### DIFF
--- a/rockspecs/luasocket-3.0.0-1.rockspec
+++ b/rockspecs/luasocket-3.0.0-1.rockspec
@@ -34,7 +34,7 @@ local function make_plat(plat)
     },
     mingw32 = {
       "LUASOCKET_DEBUG",
-      "LUASOCKET_INET_PTON",
+      -- "LUASOCKET_INET_PTON",
       "WINVER=0x0501"
     }
   }
@@ -113,6 +113,7 @@ local function make_plat(plat)
   then
     modules["socket.core"].sources[#modules["socket.core"].sources+1] = "src/wsocket.c"
     modules["socket.core"].libraries = { "ws2_32" }
+    modules["socket.core"].libdirs = {}
   end
   return { modules = modules }
 end


### PR DESCRIPTION
Closes #321.

Uses the patch I mentioned in the above issue that fixes the LuaRocks installation for my Windows system. @alerque said this needs confirmation from another Windows user and testing on *nix platforms.