### PR TITLE
Fix relative redirection on https

### DIFF
--- a/src/http.lua
+++ b/src/http.lua
@@ -300,6 +300,8 @@ local function shouldredirect(reqt, code, headers)
     if not location then return false end
     location = string.gsub(location, "%s", "")
     if location == "" then return false end
+    -- the RFC says the redirect URL may be relative
+    location = url.absolute(reqt.url, location)
     local scheme = url.parse(location).scheme
     if scheme and (not SCHEMES[scheme]) then return false end
     -- avoid https downgrades
@@ -323,8 +325,7 @@ end
 local trequest, tredirect
 
 --[[local]] function tredirect(reqt, location)
-    -- the RFC says the redirect URL has to be absolute, but some
-    -- servers do not respect that
+    -- the RFC says the redirect URL may be relative
     local newurl = url.absolute(reqt.url, location)
     -- if switching schemes, reset port and create function
     if url.parse(newurl).scheme ~= reqt.scheme then

--- a/test/httptest.lua
+++ b/test/httptest.lua
@@ -265,6 +265,37 @@ ignore = {
 }
 check_request(request, expect, ignore)
 
+-- Use https://httpbin.org/#/Dynamic_data/get_base64__value_ for testing
+-----------------------------------------------------
+io.write("testing absolute https redirection: ")
+request = {
+    url = "https://httpbin.org/redirect-to?url=https://httpbin.org/base64/THVhIFNvY2tldA=="
+}
+expect = {
+    code = 200,
+    body = "Lua Socket"
+}
+ignore = {
+    status = 1,
+    headers = 1
+}
+check_request(request, expect, ignore)
+
+-----------------------------------------------------
+io.write("testing relative https redirection: ")
+request = {
+    url = "https://httpbin.org/redirect-to?url=/base64/THVhIFNvY2tldA=="
+}
+expect = {
+    code = 200,
+    body = "Lua Socket"
+}
+ignore = {
+    status = 1,
+    headers = 1
+}
+check_request(request, expect, ignore)
+
 ------------------------------------------------------------------------
 --[[
 io.write("testing proxy with redirection: ")


### PR DESCRIPTION
Location header can now be relative: https://httpwg.org/specs/rfc9110.html#field.location

Fix #393 