### PR TITLE
Github Actions Wokflow for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,22 +13,27 @@ jobs:
       fail-fast: false
       matrix:
         luaVersion: [ "5.4", "5.3", "5.2", "5.1", "luajit", "luajit-openresty" ]
-        platform: [ "ubuntu-20.04", "macos-11" ] # "windows-2022" not supported by gh-actions-lua
+        platform: [ "ubuntu-20.04", "macos-11", "windows-2022" ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup ’msvc’
+        uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ !startsWith(matrix.luaVersion, 'luajit') }}
       - name: Setup ‘lua’
-        uses: leafo/gh-actions-lua@v9
+        uses: leso-kn/gh-actions-lua@v11-staging
         with:
           luaVersion: ${{ matrix.luaVersion }}
       - name: Setup ‘luarocks’
-        uses: leafo/gh-actions-luarocks@v4
+        uses: hishamhm/gh-actions-luarocks@master
       - name: Make and install
         run: |
-          export DEBUG=DEBUG
           luarocks make -- luasocket-scm-3.rockspec
+        env:
+          DEBUG: DEBUG
       - name: Run regression tests
+        shell: bash
         run: |
           cd test
           lua hello.lua

--- a/src/options.c
+++ b/src/options.c
@@ -58,7 +58,7 @@ int opt_meth_getoption(lua_State *L, p_opt opt, p_socket ps)
 /* binds socket to network interface */
 int opt_set_bindtodevice(lua_State *L, p_socket ps)
 {
-#if defined(__APPLE__) || defined(__WIN32__) || defined(_MSC_VER)
+#ifndef SO_BINDTODEVICE
     return luaL_error(L, "SO_BINDTODEVICE is not supported on this operating system");
 #else
     const char *dev = luaL_checkstring(L, 3);
@@ -68,7 +68,7 @@ int opt_set_bindtodevice(lua_State *L, p_socket ps)
 
 int opt_get_bindtodevice(lua_State *L, p_socket ps)
 {
-#if defined(__APPLE__) || defined(__WIN32__) || defined(_MSC_VER)
+#ifndef SO_BINDTODEVICE
     return luaL_error(L, "SO_BINDTODEVICE is not supported on this operating system");
 #else
     char dev[IFNAMSIZ];


### PR DESCRIPTION
This PR closes #414 and provides the two changes listed below.

Note that most of the required work has taken place in relation to [gh-actions-lua](https://github.com/leafo/gh-actions-lua) and has been submitted to the upstream repository: [!35](https://github.com/leafo/gh-actions-lua/pull/35), [!37](https://github.com/leafo/gh-actions-lua/pull/37), [!38](https://github.com/leafo/gh-actions-lua/pull/38) and [gh-actions-luarocks!14](https://github.com/leafo/gh-actions-luarocks/pull/14).

In the meantime this PR changes the sources of `leafo/gh-actions-lua@v9` and `leafo/gh-actions-luarocks@v4` to `leso-kn/gh-actions-lua@v11-staging` and `hishamhm/gh-actions-luarocks@master` in [build.yml](https://github.com/lunarmodules/luasocket/pull/415/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R25) until the related PRs are merged upstream.

**Contents**
- Refactor (core): Replace the check for SO_BINDTODEVICE support with a platform-independent version
- CI: Enable windows build (`windows-2022`)

**Showcase**
Successful [pipeline log](https://github.com/leso-kn/luasocket/actions/runs/6670381943) with Windows build enabled.