### PR TITLE
Fix receiveheaders function

### DIFF
--- a/src/http.lua
+++ b/src/http.lua
@@ -62,7 +62,7 @@ local function receiveheaders(sock, headers)
         -- unfold any folded values
         while string.find(line, "^%s") do
             value = value .. line
-            line = sock:receive()
+            line, err = sock:receive()
             if err then return nil, err end
         end
         -- save pair in table


### PR DESCRIPTION
It seems that error checking is needed here, otherwise in theory there will be an error in the while loop if `line` becomes false