### PR TITLE
http.request: add missing handle close (HTTP/0.9 case)

### DIFF
--- a/src/http.lua
+++ b/src/http.lua
@@ -369,8 +369,10 @@ end
     -- if it is an HTTP/0.9 server, simply get the body and we are done
     if not code then
         h:receive09body(status, nreqt.sink, nreqt.step)
+        h:close()
         return 1, 200
     elseif code == 408 then
+        h:close()
         return 1, code
     end
     local headers


### PR DESCRIPTION
I am not 100% sure that this was an error, but for other cases handle is closed.

https://github.com/lunarmodules/luasocket/blob/1fad1626900a128be724cba9e9c19a6b2fe2bf6b/src/http.lua#L393