### PR TITLE
Http header host for ipv6 address must be enclosed

### DIFF
--- a/src/http.lua
+++ b/src/http.lua
@@ -230,6 +230,10 @@ end
 local function adjustheaders(reqt)
     -- default headers
     local host = reqt.host
+    --ipv6 host address must be in []
+    if string.find(host, "^[0-9a-fA-F:]+$") then
+      host = "["..host.."]"
+    end
     local port = tostring(reqt.port)
     if port ~= tostring(SCHEMES[reqt.scheme].port) then
         host = host .. ':' .. port end

--- a/src/http.lua
+++ b/src/http.lua
@@ -231,7 +231,7 @@ local function adjustheaders(reqt)
     -- default headers
     local host = reqt.host
     --ipv6 host address must be in []
-    if string.find(host, "^[0-9a-fA-F:]+$") then
+    if host:find(":", 1, true) then
       host = "["..host.."]"
     end
     local port = tostring(reqt.port)


### PR DESCRIPTION
in square brackets. Same as is in url.

url: http://[1080:0:0:0:8:800:200C:417A]/index.html
headers.host: [1080:0:0:0:8:800:200C:417A]

url.parse removes square brackets, I rather place them back here, than break something else depanding on url.parse