### PR TITLE
Add option for SO_EXCLUSIVEADDRUSE in Windows

### DIFF
--- a/docs/tcp.html
+++ b/docs/tcp.html
@@ -236,10 +236,20 @@ option names and values.
 <p class="parameters">
 <tt>Option</tt> is a string with the option name.</p>
 <ul>
+<li> '<tt>bindtodevice</tt>'</li>
 <li> '<tt>keepalive</tt>'</li>
-<li> '<tt>linger</tt>'</li>
 <li> '<tt>reuseaddr</tt>'</li>
+<li> '<tt>exclusiveaddruse</tt>'</li>
+<li> '<tt>reuseport</tt>'</li>
 <li> '<tt>tcp-nodelay</tt>'</li>
+<li> '<tt>tcp-keepidle</tt>'</li>
+<li> '<tt>tcp-keepcnt</tt>'</li>
+<li> '<tt>tcp-keepintvl</tt>'</li>
+<li> '<tt>linger</tt>'</li>
+<li> '<tt>error</tt>': Returns the socket's pending error status, if
+any, and clears it. Get-only.</li>
+<li> '<tt>recv-buffer-size</tt>'</li>
+<li> '<tt>send-buffer-size</tt>'</li>
 </ul>
 
 <p class="return">
@@ -456,6 +466,11 @@ depends on the option being set:</p>
 
 <ul>
 
+<li> '<tt>bindtodevice</tt>': Binds the socket to a specific network
+interface, given its name (e.g. <tt>"eth0"</tt>), so that only packets
+received on that interface are processed. Receives a string. Linux
+only!!</li>
+
 <li> '<tt>keepalive</tt>':  Setting this option to <tt>true</tt> enables
 the periodic transmission of messages on a connected socket. Should the
 connected party fail to respond to these messages, the connection is
@@ -476,6 +491,14 @@ zero;</li>
 used in validating addresses supplied in a call to
 <a href="#bind"><tt>bind</tt></a> should allow reuse of local addresses;</li>
 
+<li> '<tt>exclusiveaddruse</tt>': Setting this option to <tt>true</tt>
+prevents other sockets from binding to the same address and port, even if
+those sockets set '<tt>reuseaddr</tt>'. Windows only!!</li>
+
+<li> '<tt>reuseport</tt>': Allows completely duplicate bindings by
+multiple processes if they all set '<tt>reuseport</tt>' before binding
+the port.</li>
+
 <li> '<tt>tcp-nodelay</tt>': Setting this option to <tt>true</tt>
 disables the Nagle's algorithm for the connection;</li>
 
@@ -494,6 +517,12 @@ disables the Nagle's algorithm for the connection;</li>
 <li> '<tt>ipv6-v6only</tt>':
 Setting this option to <tt>true</tt> restricts an <tt>inet6</tt> socket to
 sending and receiving only IPv6 packets.</li>
+
+<li> '<tt>recv-buffer-size</tt>': Sets the size, in bytes, of the
+socket's receive buffer (<tt>SO_RCVBUF</tt>). Receives a number.</li>
+
+<li> '<tt>send-buffer-size</tt>': Sets the size, in bytes, of the
+socket's send buffer (<tt>SO_SNDBUF</tt>). Receives a number.</li>
 </ul>
 
 <p class="return">

--- a/docs/udp.html
+++ b/docs/udp.html
@@ -80,13 +80,18 @@ description of the option names and values.
 <li> '<tt>dontroute</tt>'</li>
 <li> '<tt>broadcast</tt>'</li>
 <li> '<tt>reuseaddr</tt>'</li>
+<li> '<tt>exclusiveaddruse</tt>'</li>
 <li> '<tt>reuseport</tt>'</li>
 <li> '<tt>ip-multicast-loop</tt>'</li>
 <li> '<tt>ipv6-v6only</tt>'</li>
+<li> '<tt>ipv6-unicast-hops</tt>'</li>
+<li> '<tt>ipv6-multicast-hops</tt>'</li>
+<li> '<tt>ipv6-multicast-loop</tt>'</li>
 <li> '<tt>ip-multicast-if</tt>'</li>
-<li> '<tt>ip-multicast-ttl</tt>'</li>
-<li> '<tt>ip-add-membership</tt>'</li>
-<li> '<tt>ip-drop-membership</tt>'</li>
+<li> '<tt>error</tt>': Returns the socket's pending error status, if
+any, and clears it. Get-only.</li>
+<li> '<tt>recv-buffer-size</tt>'</li>
+<li> '<tt>send-buffer-size</tt>'</li>
 </ul>
 </p>
 
@@ -294,6 +299,10 @@ Receives a boolean value;</li>
 validating addresses supplied in a <tt>bind()</tt> call
 should allow reuse of local addresses.
 Receives a boolean value;</li>
+<li> '<tt>exclusiveaddruse</tt>': Setting this option to <tt>true</tt>
+prevents other sockets from binding to the same address and port, even
+if those sockets set '<tt>reuseaddr</tt>'.
+Receives a boolean value. Windows only!!</li>
 <li> '<tt>reuseport</tt>': Allows completely duplicate
 bindings by multiple processes if they all set
 '<tt>reuseport</tt>' before binding the port.
@@ -307,6 +316,28 @@ Receives a boolean value;</li>
 Specifies whether to restrict <tt>inet6</tt> sockets to
 sending and receiving only IPv6 packets.
 Receive a boolean value;</li>
+<li> '<tt>ipv6-unicast-hops</tt>':
+Sets the unicast hop limit (the IPv6 equivalent of the IPv4 TTL)
+for outgoing packets.
+Receives a number;</li>
+<li> '<tt>ipv6-multicast-hops</tt>':
+Sets the hop limit for outgoing IPv6 multicast datagrams.
+Receives a number;</li>
+<li> '<tt>ipv6-multicast-loop</tt>':
+Specifies whether or not a copy of an outgoing IPv6 multicast
+datagram is delivered to the sending host as long as it is a
+member of the multicast group.
+Receives a boolean value;</li>
+<li> '<tt>ipv6-add-membership</tt>':
+Joins the IPv6 multicast group specified.
+Receives a table with field
+<tt>multiaddr</tt>, an IPv6 address, and optionally
+<tt>interface</tt>, a network interface index number;</li>
+<li> '<tt>ipv6-drop-membership</tt>': Leaves the IPv6 multicast
+group specified.
+Receives a table with field
+<tt>multiaddr</tt>, an IPv6 address, and optionally
+<tt>interface</tt>, a network interface index number;</li>
 <li> '<tt>ip-multicast-if</tt>':
 Sets the interface over which outgoing multicast datagrams
 are sent.
@@ -324,7 +355,13 @@ IP address;</li>
 group specified.
 Receives a table with fields
 <tt>multiaddr</tt> and <tt>interface</tt>, each containing an
-IP address.</li>
+IP address;</li>
+<li> '<tt>recv-buffer-size</tt>': Sets the size, in bytes, of the
+socket's receive buffer (<tt>SO_RCVBUF</tt>).
+Receives a number;</li>
+<li> '<tt>send-buffer-size</tt>': Sets the size, in bytes, of the
+socket's send buffer (<tt>SO_SNDBUF</tt>).
+Receives a number.</li>
 </ul>
 
 <p class="return">

--- a/src/options.c
+++ b/src/options.c
@@ -94,6 +94,26 @@ int opt_get_reuseaddr(lua_State *L, p_socket ps)
 }
 
 /*------------------------------------------------------*/
+/* enables reuse of local address */
+int opt_set_exclusiveaddruse(lua_State* L, p_socket ps)
+{
+#ifndef SO_EXCLUSIVEADDRUSE
+    return luaL_error(L, "SO_EXCLUSIVEADDRUSE is not supported on this operating system");
+#else
+    return opt_setboolean(L, ps, SOL_SOCKET, SO_EXCLUSIVEADDRUSE);
+#endif
+}
+
+int opt_get_exclusiveaddruse(lua_State* L, p_socket ps)
+{
+#ifndef SO_EXCLUSIVEADDRUSE
+    return luaL_error(L, "SO_EXCLUSIVEADDRUSE is not supported on this operating system");
+#else
+    return opt_getboolean(L, ps, SOL_SOCKET, SO_EXCLUSIVEADDRUSE);
+#endif
+}
+
+/*------------------------------------------------------*/
 /* enables reuse of local port */
 int opt_set_reuseport(lua_State *L, p_socket ps)
 {

--- a/src/options.h
+++ b/src/options.h
@@ -28,6 +28,11 @@ int opt_meth_getoption(lua_State *L, p_opt opt, p_socket ps);
 int opt_set_reuseaddr(lua_State *L, p_socket ps);
 int opt_get_reuseaddr(lua_State *L, p_socket ps);
 
+#ifdef SO_EXCLUSIVEADDRUSE
+int opt_set_exclusiveaddruse(lua_State* L, p_socket ps);
+int opt_get_exclusiveaddruse(lua_State* L, p_socket ps);
+#endif
+
 int opt_set_reuseport(lua_State *L, p_socket ps);
 int opt_get_reuseport(lua_State *L, p_socket ps);
 

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -74,6 +74,9 @@ static t_opt optget[] = {
     {"bindtodevice", opt_get_bindtodevice},
     {"keepalive",   opt_get_keepalive},
     {"reuseaddr",   opt_get_reuseaddr},
+#ifdef SO_EXCLUSIVEADDRUSE
+    {"exclusiveaddruse", opt_get_exclusiveaddruse},
+#endif
     {"reuseport",   opt_get_reuseport},
     {"tcp-nodelay", opt_get_tcp_nodelay},
 #ifdef TCP_KEEPIDLE
@@ -96,6 +99,9 @@ static t_opt optset[] = {
     {"bindtodevice", opt_set_bindtodevice},
     {"keepalive",   opt_set_keepalive},
     {"reuseaddr",   opt_set_reuseaddr},
+#ifdef SO_EXCLUSIVEADDRUSE
+    {"exclusiveaddruse", opt_set_exclusiveaddruse},
+#endif
     {"reuseport",   opt_set_reuseport},
     {"tcp-nodelay", opt_set_tcp_nodelay},
 #ifdef TCP_KEEPIDLE

--- a/src/udp.c
+++ b/src/udp.c
@@ -74,6 +74,9 @@ static t_opt optset[] = {
     {"dontroute",            opt_set_dontroute},
     {"broadcast",            opt_set_broadcast},
     {"reuseaddr",            opt_set_reuseaddr},
+#ifdef SO_EXCLUSIVEADDRUSE
+    {"exclusiveaddruse", opt_set_exclusiveaddruse},
+#endif
     {"reuseport",            opt_set_reuseport},
     {"ip-multicast-if",      opt_set_ip_multicast_if},
     {"ip-multicast-ttl",     opt_set_ip_multicast_ttl},
@@ -96,6 +99,9 @@ static t_opt optget[] = {
     {"dontroute",            opt_get_dontroute},
     {"broadcast",            opt_get_broadcast},
     {"reuseaddr",            opt_get_reuseaddr},
+#ifdef SO_EXCLUSIVEADDRUSE
+    {"exclusiveaddruse", opt_get_exclusiveaddruse},
+#endif
     {"reuseport",            opt_get_reuseport},
     {"ip-multicast-if",      opt_get_ip_multicast_if},
     {"ip-multicast-loop",    opt_get_ip_multicast_loop},


### PR DESCRIPTION
Self-explanatory PR.  I found a use case for this in my project so I am submitting the PR upstream.  

See the MSDN docs for an explanation: https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse

