### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         luaVersion: [ "5.4", "5.3", "5.2", "5.1", "luajit", "luajit-openresty" ]
-        platform: [ "ubuntu-22.04", "macos-11", "windows-2022" ]
+        platform: [ "ubuntu-22.04", "macos-14", "windows-2022" ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,11 @@ jobs:
         if: ${{ startsWith(matrix.platform, 'windows') && !startsWith(matrix.luaVersion, 'luajit') }}
         uses: ilammy/msvc-dev-cmd@v1
       - name: Setup ‘lua’
-        uses: leso-kn/gh-actions-lua@v11-staging
+        uses: luarocks/gh-actions-lua@v10
         with:
           luaVersion: ${{ matrix.luaVersion }}
       - name: Setup ‘luarocks’
-        uses: hishamhm/gh-actions-luarocks@master
+        uses: luarocks/gh-actions-luarocks@v5
       - name: Make and install
         run: |
           luarocks make -- luasocket-scm-3.rockspec


### PR DESCRIPTION
## Description

The proposed changes allow ```luasocket``` to be tested on macOS.

## Changes

1. Using the latest GitHub Actions from LuaRocks to install Lua ([https://github.com/luarocks/gh-actions-lua](https://github.com/luarocks/gh-actions-lua)) and LuaRocks ([https://github.com/luarocks/gh-actions-luarocks](https://github.com/luarocks/gh-actions-luarocks));
2. Using ```macos-14``` runner image, because the used version (```macos-11```) is not supported anymore. See the supported versions [https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images](https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images).

## Notes

With the proposed changes, ```luasocket``` CI is still failing on ```luajit``` and ```openresty``` on Windows. However, since this behavior was happening on Windows before this PR, it is unlikely that this failure was caused by the changes.