### PR TITLE
CI: fix the build for LuaJIT and OpenResty on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
           luaVersion: ${{ matrix.luaVersion }}
       - name: Setup ‘luarocks’
         uses: luarocks/gh-actions-luarocks@v5
+      - name: Fix ’MSVCRT’ for luajit and luajit-openresty on Windows
+        if: ${{ startsWith(matrix.platform, 'windows') && startsWith(matrix.luaVersion, 'luajit') }}
+        run: luarocks config variables.MSVCRT UCRTBASE
       - name: Make and install
         run: |
           luarocks make -- luasocket-scm-3.rockspec

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
         uses: luarocks/gh-actions-lua@v10
         with:
           luaVersion: ${{ matrix.luaVersion }}
+          buildCache: false
       - name: Setup ‘luarocks’
         uses: luau-project/gh-actions-luarocks@fix-mingw-MSVCRT
       - name: Make and install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,7 @@ jobs:
         with:
           luaVersion: ${{ matrix.luaVersion }}
       - name: Setup ‘luarocks’
-        uses: luarocks/gh-actions-luarocks@v5
-      - name: Fix ’MSVCRT’ for luajit and luajit-openresty on Windows
-        if: ${{ startsWith(matrix.platform, 'windows') && startsWith(matrix.luaVersion, 'luajit') }}
-        run: luarocks config variables.MSVCRT UCRTBASE
-      - name: Fix ’LUA_LIBDIR’ for luajit-openresty on Windows
-        if: ${{ startsWith(matrix.platform, 'windows') && matrix.luaVersion == 'luajit-openresty' }}
-        run: luarocks config variables.LUA_LIBDIR "${{ github.workspace }}\.lua\bin"
+        uses: luau-project/gh-actions-luarocks@fix-mingw-MSVCRT
       - name: Make and install
         run: |
           luarocks make -- luasocket-scm-3.rockspec

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Fix ’MSVCRT’ for luajit and luajit-openresty on Windows
         if: ${{ startsWith(matrix.platform, 'windows') && startsWith(matrix.luaVersion, 'luajit') }}
         run: luarocks config variables.MSVCRT UCRTBASE
+      - name: Fix ’LUA_LIBDIR’ for luajit-openresty on Windows
+        if: ${{ startsWith(matrix.platform, 'windows') && matrix.luaVersion == 'luajit-openresty' }}
+        run: luarocks config variables.LUA_LIBDIR "${{ github.workspace }}\.lua\bin"
       - name: Make and install
         run: |
           luarocks make -- luasocket-scm-3.rockspec


### PR DESCRIPTION
## Description

Fixed the CI build of `luasocket` for LuaJIT and OpenResty on Windows. Now, CI is working correctly on all scenarios.

## Changes

1. Currently, most MinGW-w64 providers *(like the one used by GitHub)* ship a C compiler targeting the Universal C Run Time (UCRT). However, the current LuaRocks version (3.11.1) used by most GitHub Actions incorrectly detects the MSVCRT of LuaJIT and OpenResty on Windows. Thus, `MSVCRT` was set explicitly to UCRTBASE;

> [!NOTE]
> 
> This LuaRocks issue was already fixed by [https://github.com/luarocks/luarocks/commit/99c7267241e6ed0ef62123187acf7a5539a6c2db](https://github.com/luarocks/luarocks/commit/99c7267241e6ed0ef62123187acf7a5539a6c2db). However, it was merged after LuaRocks 3.11.1 release.

2. LuaRocks is unable to detect the library directory of OpenResty on Windows. Thus, `LUA_LIBDIR` was set explicitly to the binary directory of Lua for OpenResty on Windows.