### PR TITLE
Improve installation instructions: Focus on LuaRocks installation

### DIFF
--- a/docs/installation.html
+++ b/docs/installation.html
@@ -37,7 +37,7 @@ Installation">
 
 <!-- installation ++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 
-<h1>Installation via luarocks</h1>
+<h2>Installation via luarocks</h2>
 
 
 
@@ -50,7 +50,7 @@ Installation">
 luarocks install luasocket
 </pre>
 
-<h2>Verification</h2>
+<h3>Verification</h3>
     <p>To verify that LuaSocket is installed correctly, open Lua and run:</p>
     <pre class=example><code>
    local socket = require("socket")
@@ -59,7 +59,7 @@ luarocks install luasocket
 
 <p>If you see output like <strong>LuaSocket 3.0</strong>, the installation was successful.</p>
 
-<h2>More Information</h2>
+<h3>More Information</h3>
 <p>For more details, visit the <a href="https://github.com/lunarmodules/luasocket" target="_blank">LuaSocket GitHub repository</a>.</p>
 
 <!-- footer +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -37,70 +37,30 @@ Installation">
 
 <!-- installation ++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 
-<h2>Installation</h2>
+<h1>Installation via luarocks</h1>
 
-<p> Here we describe the standard distribution.  If the
-standard doesn't meet your needs, we refer you to the Lua
-discussion list, where any question about the package scheme
-will likely already have been answered.  </p>
 
-<h3>Directory structure</h3>
 
-<p> On Unix systems, the standard distribution uses two base
-directories, one for system dependent files, and another for system
-independent files. Let's call these directories <tt>&lt;CDIR&gt;</tt>
-and <tt>&lt;LDIR&gt;</tt>, respectively.
-For example, in my laptp, Lua&nbsp;5.1 is configured to
-use '<tt>/usr/local/lib/lua/5.1</tt>' for
-<tt>&lt;CDIR&gt;</tt> and '<tt>/usr/local/share/lua/5.1</tt>' for
-<tt>&lt;LDIR&gt;</tt>. On Windows, <tt>&lt;CDIR&gt;</tt>
-usually points to the directory where the Lua executable is
-found, and <tt>&lt;LDIR&gt;</tt> points to a
-<tt>lua/</tt> directory inside <tt>&lt;CDIR&gt;</tt>. (These
-settings can be overridden by environment variables
-<tt>LUA_PATH</tt> and <tt>LUA_CPATH</tt>. See the Lua
-documentation for details.) Here is the standard LuaSocket
-distribution directory structure:</p>
+<p>LuaSocket can be easily installed using <a href="https://luarocks.org/" target="_blank">LuaRocks</a>, the Lua package manager.</p>
 
+<h3>Installing via LuaRocks</h3>
+
+<p>Run the following command in your terminal:</p>
 <pre class=example>
-&lt;LDIR&gt;/ltn12.lua
-&lt;LDIR&gt;/socket.lua
-&lt;CDIR&gt;/socket/core.dll
-&lt;LDIR&gt;/socket/http.lua
-&lt;LDIR&gt;/socket/tp.lua
-&lt;LDIR&gt;/socket/ftp.lua
-&lt;LDIR&gt;/socket/smtp.lua
-&lt;LDIR&gt;/socket/url.lua
-&lt;LDIR&gt;/mime.lua
-&lt;CDIR&gt;/mime/core.dll
+luarocks install luasocket
 </pre>
 
-<p> Naturally, on Unix systems, <tt>core.dll</tt>
-would be replaced by <tt>core.so</tt>.
-</p>
+<h2>Verification</h2>
+    <p>To verify that LuaSocket is installed correctly, open Lua and run:</p>
+    <pre class=example><code>
+   local socket = require("socket")
+   print(socket._VERSION)
+    </code></pre>
 
-<h3>Using LuaSocket</h3>
+<p>If you see output like <strong>LuaSocket 3.0</strong>, the installation was successful.</p>
 
-<p> With the above setup, and an interpreter with shared library support,
-it should be easy to use LuaSocket. Just fire the interpreter and use the
-<tt>require</tt> function to gain access to whatever module you need:</p>
-
-<pre class=example>
-Lua 5.2.2  Copyright (C) 1994-2013 Lua.org, PUC-Rio
-&gt; socket = require("socket")
-&gt; print(socket._VERSION)
---&gt; LuaSocket 3.1.0
-</pre>
-
-<p> Each module loads their dependencies automatically, so you only need to
-load the modules you directly depend upon: </p>
-
-<pre class=example>
-Lua 5.2.2  Copyright (C) 1994-2013 Lua.org, PUC-Rio
-&gt; http = require("socket.http")
-&gt; print(http.request("http://www.impa.br/~diego/software/luasocket"))
---&gt; homepage gets dumped to terminal
-</pre>
+<h2>More Information</h2>
+<p>For more details, visit the <a href="https://github.com/lunarmodules/luasocket" target="_blank">LuaSocket GitHub repository</a>.</p>
 
 <!-- footer +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 


### PR DESCRIPTION
###  Description
->Removed "Installation via standard distribution" and "Directory structure" sections to avoid confusion.
->Focused on LuaRocks installation as the recommended method.

### Why this change?
->LuaRocks is the standard way to install LuaSocket, and the manual installation details were unnecessary.
->Simplifies the documentation for new users.
->How the installation page would look like after this Pull request gets merged :
![Screenshot 2025-03-15 173613](https://github.com/user-attachments/assets/64fd6c3c-b927-401a-ae45-6dba474861d2)


### Testing
->Verified that the new instructions correctly install LuaSocket via LuaRocks.

### Issue Reference 
solves issue #220 