### PR TITLE
Handle response code 308 permanent redirect

### DIFF
--- a/src/http.lua
+++ b/src/http.lua
@@ -312,7 +312,7 @@ local function shouldredirect(reqt, code, headers)
     -- avoid https downgrades
     if ('https' == reqt.scheme) and ('https' ~= scheme) then return false end
     return (reqt.redirect ~= false) and
-           (code == 301 or code == 302 or code == 303 or code == 307) and
+           (code == 301 or code == 302 or code == 303 or code == 307 or code == 308) and
            (not reqt.method or reqt.method == "GET" or reqt.method == "HEAD")
         and ((false == reqt.maxredirects)
                 or ((reqt.nredirects or 0)


### PR DESCRIPTION
Currently the http module lets through response code 308. It should be treated like a 301 for any reasonable user agent. Its actual only purpose is to emphasise that the request method must not change.

I'm only here because of https://github.com/koreader/koreader/issues/15584, I don't actually know lua but this is a simple enough fix that I could manage it.